### PR TITLE
Wv debugfree

### DIFF
--- a/particles/LATfield2_Particles.hpp
+++ b/particles/LATfield2_Particles.hpp
@@ -628,7 +628,7 @@ void Particles<part,part_info,part_dataType>::moveParticles( void (*move_funct)(
     
     //LATfield2::Site xB;
     
-    LATfield2::Site * sites;
+    LATfield2::Site * sites = NULL;
     
     typename std::list<part>::iterator it,itTemp;
     //Real b[3];
@@ -882,7 +882,10 @@ void Particles<part,part_info,part_dataType>::moveParticles( void (*move_funct)(
         }
     }
     delete[] output_temp;
-    if(nfields!=0)delete[] sites;
+    if(nfields!=0) {
+      if(sites) delete[] sites;
+      else { std::cerr << "WTF, nfields != 0, but sites is not initialized.\n"; exit(-1); }
+    }
 
     //remove the number of part...
     for(int i=0;i<8;i++)

--- a/particles/LATfield2_Particles.hpp
+++ b/particles/LATfield2_Particles.hpp
@@ -882,10 +882,11 @@ void Particles<part,part_info,part_dataType>::moveParticles( void (*move_funct)(
         }
     }
     delete[] output_temp;
-    if(nfields!=0) {
-      if(sites) delete[] sites;
-      else { std::cerr << "WTF, nfields != 0, but sites is not initialized.\n"; exit(-1); }
-    }
+    /* this is wrong: sites gets deleted again later */
+    //    if(nfields!=0) {
+    //      if(sites) delete[] sites;
+    //      else { std::cerr << "WTF, nfields != 0, but sites is not initialized.\n"; exit(-1); }
+    //    }
 
     //remove the number of part...
     for(int i=0;i<8;i++)
@@ -1506,7 +1507,7 @@ void Particles<part,part_info,part_dataType>::moveParticles( void (*move_funct)(
     delete[] sendBuffer;
     delete[] recBuffer;
     
-    if(nfields!=0) delete[] sites;
+  if(nfields!=0 && sites) { delete[] sites; sites = NULL; };
     
 }
 


### PR DESCRIPTION
I commented one line, which caused a crash: sites were deleted twice in the same routine. 

This makes gevolution run properly with this branch of latfield, if and only if you compile with gcc. 

On OS X with clang, it strangely crashed when trying to return an end pointer to one of the particle lists in moveParticles. No idea why.
