### PR TITLE
automatic hdf5.h inclusion

### DIFF
--- a/LATfield2.hpp
+++ b/LATfield2.hpp
@@ -22,7 +22,7 @@
 
 
 #ifdef HDF5
-#include "hdf5.h"
+#include <hdf5.h>
 
 
 
@@ -81,7 +81,7 @@ Parallel2d parallel;
 
 
 #ifdef HDF5
-#include "hdf5.h"
+#include <hdf5.h>
 #ifdef H5_HAVE_PIXIE
 #include "LATfield2_save_hdf5_pixie.h"
 #else


### PR DESCRIPTION
The hdf5.h header file should be included automatically from the system,
using -I and -L in the makefile, or configure.ac to create the makefile.
