### PR TITLE
No global MPI

### DIFF
--- a/LATfield2_parallel2d.hpp
+++ b/LATfield2_parallel2d.hpp
@@ -16,37 +16,28 @@
 
 Parallel2d::Parallel2d() : neverFinalizeMPI(false)
 {
-
-
-	int argc=1;
-	char** argv = new char*[argc];
-	for(int i=0; i<argc; i++) { argv[i]=new char[20]; }
-#ifndef EXTERNAL_IO
-	lat_world_comm_ = MPI_COMM_WORLD;
-    world_comm_ = MPI_COMM_WORLD;
-	MPI_Init( &argc, &argv );
-	MPI_Comm_rank( lat_world_comm_, &lat_world_rank_ );
-	MPI_Comm_size( lat_world_comm_, &lat_world_size_ );
-    MPI_Comm_rank( world_comm_, &world_rank_ );
-	MPI_Comm_size( world_comm_, &world_size_ );
-#else
-    world_comm_ = MPI_COMM_WORLD;
-	MPI_Init( &argc, &argv );
-    MPI_Comm_rank( world_comm_, &world_rank_ );
-	MPI_Comm_size( world_comm_, &world_size_ );
-
-#endif
-
 }
 
-void Parallel2d::initialize(int proc_size0, int proc_size1)
+void Parallel2d::initialize(MPI_Comm com,int proc_size0, int proc_size1)
 {
-    this->initialize(proc_size0, proc_size1,0,0);
+    this->initialize(com,proc_size0, proc_size1,0,0);
 }
 
 
-void Parallel2d::initialize(int proc_size0, int proc_size1,int IO_total_size, int IO_node_size)
+void Parallel2d::initialize(MPI_Comm com, int proc_size0, int proc_size1,int IO_total_size, int IO_node_size)
 {
+    #ifndef EXTERNAL_IO
+    lat_world_comm_ = com;
+    world_comm_ = com;
+    MPI_Comm_rank( lat_world_comm_, &lat_world_rank_ );
+    MPI_Comm_size( lat_world_comm_, &lat_world_size_ );
+    MPI_Comm_rank( world_comm_, &world_rank_ );
+    MPI_Comm_size( world_comm_, &world_size_ );
+    #else
+    world_comm_ = com;
+    MPI_Comm_rank( world_comm_, &world_rank_ );
+    MPI_Comm_size( world_comm_, &world_size_ );
+    #endif
 
     grid_size_[0]=proc_size0;
 	grid_size_[1]=proc_size1;
@@ -229,7 +220,9 @@ Parallel2d::~Parallel2d()
 {
 	int finalized;
   MPI_Finalized(&finalized);
-  if((!finalized) && (!neverFinalizeMPI)) { MPI_Finalize(); }
+  if((!finalized) && (!neverFinalizeMPI)) { 
+    // MPI_Finalize();
+  }
 }
 
 //ABORT AND BARRIER===============================

--- a/LATfield2_parallel2d_decl.hpp
+++ b/LATfield2_parallel2d_decl.hpp
@@ -53,7 +53,7 @@ class Parallel2d{
    \param IO_total_size : number of MPI process reserved for the IO server.
    \param IO_node_size  : size of 1 goupe of process reserved for the IO server. Each group will write in a seperated file.
    */
-  void initialize(int proc_size0, int proc_size1,int IO_total_size, int IO_node_size);
+  void initialize(MPI_Comm com,int proc_size0, int proc_size1,int IO_total_size, int IO_node_size);
 
   /*!
    Overall LATfield2 initialization used when the output server is not used. Should be the first call in any LATfield2 based application, as it initialize MPI.
@@ -61,7 +61,7 @@ class Parallel2d{
    \param proc_size0 : size of the first dimension of the MPI process grid.
    \param proc_size1 : size of the second dimension of the MPI process grid.
    */
-  void initialize(int proc_size0, int proc_size1);
+  void initialize(MPI_Comm com,int proc_size0, int proc_size1);
 
   //ABORT AND BARRIER===============================
 

--- a/benchmarks_tests/benchmarks.cpp
+++ b/benchmarks_tests/benchmarks.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include "LATfield2d.hpp"
+#include <mpi.h>
 
 using namespace LATfield2d;
 
@@ -16,6 +17,7 @@ using namespace LATfield2d;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int n,m;
     int BoxSize=64;
     int runs=3;
@@ -47,7 +49,7 @@ int main(int argc, char **argv)
 	}
 
 	
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
     
     
     int halo = 1;
@@ -292,5 +294,6 @@ int main(int argc, char **argv)
 
 
 
+    MPI_Finalize();
 }
    

--- a/benchmarks_tests/benchmarks_particles.cpp
+++ b/benchmarks_tests/benchmarks_particles.cpp
@@ -1,11 +1,13 @@
 #include <stdlib.h>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
     
+    MPI_Init(&argc,&argv);
     
     int n,m;
     int io_groupe_size,io_size;
@@ -47,10 +49,10 @@ int main(int argc, char **argv)
     }
     
 #ifndef EXTERNAL_IO
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 #else
     
-    parallel.initialize(n,m,io_size,io_groupe_size);
+    parallel.initialize(MPI_COMM_WORLD,n,m,io_size,io_groupe_size);
     if(parallel.isIO()) ioserver.start();
     else
     {
@@ -253,5 +255,6 @@ int main(int argc, char **argv)
         ioserver.stop();
     }
 #endif
+    MPI_Finalize();
 }
 

--- a/benchmarks_tests/benchmarks_server.cpp
+++ b/benchmarks_tests/benchmarks_server.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
@@ -16,6 +17,7 @@ using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int l,m;
     int io_size;
     int io_groupe_size;
@@ -50,7 +52,7 @@ int main(int argc, char **argv)
 	}
 
 	
-    parallel.initialize(l,m,io_size,io_groupe_size);
+    parallel.initialize(MPI_COMM_WORLD,l,m,io_size,io_groupe_size);
     
     if(parallel.isIO())ioserver.start();
     else
@@ -156,5 +158,6 @@ int main(int argc, char **argv)
     
     
     
+    MPI_Finalize();
 }
    

--- a/benchmarks_tests/particles/testParticles.cpp
+++ b/benchmarks_tests/particles/testParticles.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 
 using namespace LATfield2;
@@ -8,6 +9,7 @@ using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 	
 	
 	int n,m;
@@ -33,7 +35,7 @@ int main(int argc, char **argv)
 	}
 	
 	
-    parallel.initialize(n,m,io_size,io_groupe_size);
+    parallel.initialize(MPI_COMM_WORLD,n,m,io_size,io_groupe_size);
     
     if(parallel.isIO()) IO_Server.start();
     else
@@ -218,6 +220,7 @@ int main(int argc, char **argv)
     }
 	
 	
+    MPI_Finalize();
     
 }
 

--- a/benchmarks_tests/wave_test.cpp
+++ b/benchmarks_tests/wave_test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <iomanip>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
@@ -14,6 +15,7 @@ double chop(const double val, const double tol)
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int n,m;
     int BoxSize = 64;
     int halo = 1;
@@ -41,7 +43,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     Lattice lat(dim,BoxSize,halo);
     Lattice latK;
@@ -169,6 +171,7 @@ int main(int argc, char **argv)
 
     parallel.sum(count);
 
+    MPI_Finalize();
     exit(count);
 }
 

--- a/benchmarks_tests/wave_test_back.cpp
+++ b/benchmarks_tests/wave_test_back.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <iomanip>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
@@ -14,6 +15,7 @@ double chop(const double val, const double tol)
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int n,m;
     int BoxSize = 64;
     int halo = 1;
@@ -41,7 +43,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     Lattice lat(dim,BoxSize,halo);
     Lattice latK;
@@ -156,6 +158,7 @@ int main(int argc, char **argv)
 
     parallel.sum(count);
 
+    MPI_Finalize();
     exit(count);
 }
 

--- a/examples/benchmark.cpp
+++ b/examples/benchmark.cpp
@@ -6,12 +6,14 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 #include <scorep/SCOREP_User.h>
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -45,7 +47,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     COUT << "Parallel grid size: ("<<parallel.grid_size()[0]<<","<<parallel.grid_size()[1]<<"). "<<endl;
     //-----------------------   end   ------------------------
@@ -280,6 +282,7 @@ timer_udHalo_10comp = 0.0;
 
 
 
+    MPI_Finalize();
 
 
 }

--- a/examples/boundary_test.cpp
+++ b/examples/boundary_test.cpp
@@ -6,11 +6,13 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -28,7 +30,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     //  parallel.PleaseNeverFinalizeMPI();
 
@@ -143,7 +145,7 @@ int main(int argc, char **argv)
 */
 
 
-//    MPI_Finalize();
+    MPI_Finalize();
 
 
 

--- a/examples/exercice/parallel_ex1.cpp
+++ b/examples/exercice/parallel_ex1.cpp
@@ -6,11 +6,13 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -27,11 +29,12 @@ int main(int argc, char **argv)
 				break;
 		}
 	}
-  parallel.initialize(n,m);
+  parallel.initialize(MPI_COMM_WORLD,n,m);
 
     COUT << "Parallel grid size: ("<<parallel.grid_size()[0]<<","<<parallel.grid_size()[1]<<"). "<<endl;
     //-----------------------   end   ------------------------
 
   
+    MPI_Finalize();
 
 }

--- a/examples/fft.cpp
+++ b/examples/fft.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
@@ -17,6 +18,7 @@ using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int n,m;
     int BoxSize = 64;
     int halo = 1;
@@ -43,7 +45,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	parallel.initialize(n,m);
+	parallel.initialize(MPI_COMM_WORLD,n,m);
 
 
     Lattice lat;
@@ -77,5 +79,6 @@ int main(int argc, char **argv)
     planReal.execute(FFT_BACKWARD);
 
     
+    MPI_Finalize();
 
 }

--- a/examples/gettingStarted.cpp
+++ b/examples/gettingStarted.cpp
@@ -6,11 +6,13 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -28,7 +30,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     COUT << "Parallel grid size: ("<<parallel.grid_size()[0]<<","<<parallel.grid_size()[1]<<"). "<<endl;
     //-----------------------   end   ------------------------
@@ -98,5 +100,6 @@ int main(int argc, char **argv)
 #endif
 
 
+    MPI_Finalize();
     //--------------------------------------------------------
 }

--- a/examples/particles.cpp
+++ b/examples/particles.cpp
@@ -1,11 +1,12 @@
 #include <stdlib.h>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
-
+    MPI_Init(&argc,&argv);
 
     int n,m;
     int io_groupe_size,io_size;
@@ -47,10 +48,10 @@ int main(int argc, char **argv)
     }
 
 #ifndef EXTERNAL_IO
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 #else
 
-    parallel.initialize(n,m,io_size,io_groupe_size);
+    parallel.initialize(MPI_COMM_WORLD,n,m,io_size,io_groupe_size);
     if(parallel.isIO()) ioserver.start();
     else
     {
@@ -254,4 +255,5 @@ int main(int argc, char **argv)
         ioserver.stop();
     }
 #endif
+    MPI_Finalize();
 }

--- a/examples/particles_IOissue.cpp
+++ b/examples/particles_IOissue.cpp
@@ -1,11 +1,13 @@
 #include <stdlib.h>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
     
+    MPI_Init(&argc,&argv);
     
     int n,m;
     int io_groupe_size,io_size;
@@ -29,7 +31,7 @@ int main(int argc, char **argv)
     }
     
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
         int dim=3;
         int halo=1;
@@ -115,5 +117,6 @@ int main(int argc, char **argv)
         parts.loadHDF5("bench_part",2);
         timerLoad = MPI_Wtime() - timerRef;
         
+    MPI_Finalize();
 }
 

--- a/examples/poissonSolver.cpp
+++ b/examples/poissonSolver.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include "LATfield2.hpp"
+#include <mpi.h>
 
 using namespace LATfield2;
 
@@ -17,6 +18,7 @@ using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
     int n,m;
     int BoxSize = 64;
     int halo = 1;
@@ -43,7 +45,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	parallel.initialize(n,m);
+	parallel.initialize(MPI_COMM_WORLD,n,m);
 
 
     double res2 =res*res;
@@ -157,4 +159,5 @@ int main(int argc, char **argv)
 #endif
     if (maxError > TOLERANCE) exit(max(1, 1 + (int) fabs(log10(maxError))));
     else exit(0);
+    MPI_Finalize();
 }

--- a/examples/test_sum.cpp
+++ b/examples/test_sum.cpp
@@ -6,11 +6,13 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -28,7 +30,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     COUT << "Parallel grid size: ("<<parallel.grid_size()[0]<<","<<parallel.grid_size()[1]<<"). "<<endl;
     //-----------------------   end   ------------------------
@@ -141,4 +143,5 @@ int main(int argc, char **argv)
 
 
     //--------------------------------------------------------
+    MPI_Finalize();
 }

--- a/examples/vector_prof.cpp
+++ b/examples/vector_prof.cpp
@@ -6,6 +6,7 @@
 
 
 #include "LATfield2.hpp"
+#include <mpi.h>
 using namespace LATfield2;
 
 #include <scorep/SCOREP_User.h>
@@ -22,6 +23,7 @@ using namespace LATfield2;
 
 int main(int argc, char **argv)
 {
+    MPI_Init(&argc,&argv);
 
     //-------- Initilization of the parallel object ---------
     int n,m;
@@ -47,7 +49,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-    parallel.initialize(n,m);
+    parallel.initialize(MPI_COMM_WORLD,n,m);
 
     SCOREP_USER_REGION_DEFINE(fadd_comp)
     SCOREP_USER_REGION_DEFINE(fder3)
@@ -126,5 +128,6 @@ int main(int argc, char **argv)
     COUT<<"field deriv_3p old time: "<<timer.timer(T_FDER3_OLD)<<endl;
     cout<<"done"<<endl;
     //--------------------------------------------------------
+    MPI_Finalize();
 
 }


### PR DESCRIPTION
The main purpose of Latfield is to provide the user with the concept of "Field" in distributed memory systems.
To that end, it **uses** the MPI api. It is not compulsory, in any way, to give Latfield the power to handle the global MPI environment, ie. by calling `MPI_Init` on initialization and `MPI_Finalize` on destruction, and use the entire set of communication `MPI_COMM_WORLD`. Therefore it is unwise to strip the user from the choice to let the library do that work on his/her behalf.

Take for example another C++ library that wraps the C bindings of MPI: [`boost::mpi`](https://www.boost.org/doc/libs/1_74_0/doc/html/mpi/c_mapping.html). It does all the necessary initialization and cleanup in C++ compliant way, and yet the user can choose to make explicit the call to `MPI_Init`/`MPI_Finalize` if he/she needs to. MPI resources is trivial case of resource handling, it shouldn't become resource *grabbing*.

Did you ever wonder why when using FFTW-MPI you still have to explicitly call `MPI_Init`/`MPI_Finalize` in the user code even though there is also and `fftw_mpi_init`? It is just because FFTW people did the right thing: FFTW handles the Fourier transforms, other libraries or user code must handle the MPI resources.

This philosophy of *do your job and let others do theirs* is meant to increase library compatibility. Imagine that we had a library called *X* that for certain reason it must acquire and release the MPI resources implicitly, or is it maybe that the developers were not aware of this issue and they did exactly as Latfield does. Then the users would not be able to use both Latfield and X on their code, they are simply non compatible because they both want to call  `MPI_Init`/`MPI_Finalize`.
In a good library design the user must be able to run X and Latfield, and if he wants to he/she should be able to run X on an `MPI_Comm` containing processes 0,1,2 while running Latfield on processes 3,4,5 and 6.

This PR is all about the **correct** design for parallel library. The following changes are implemented:
1. the global variable `parallel` remains, but it doesn't acquire MPI resources on construction,
2. `parallel` never releases MPI resources on destruction,
3. on initialization, `parallel` must be provided with an `MPI_Comm`; Latfield will work on the subset of processes contained in that communicator.

On the user side one should call `MPI_Init`/`MPI_Finalize` explicitly.
For example the former code
```
int main()
{
//...
parallel.initialize(n,m);
//...
}
```
becomes
```
int main()
{
MPI_Init(NULL,NULL);
//...
parallel.initialize(MPI_COMM_WORLD,n,m);
//...
MPI_Finalize();
}
```