### PR TITLE
Particles mass

### DIFF
--- a/Imag.hpp
+++ b/Imag.hpp
@@ -6,6 +6,9 @@
 
  */
 
+namespace LATfield2
+{
+
 #ifdef SINGLE
 typedef float Real; /*! \typedef Real
                         \brief real numbers
@@ -94,8 +97,8 @@ class Imag
   friend Imag expi(Real x) { return Imag( std::cos(x), std::sin(x) ); }
 
   //I/O STREAM OPERATORS
-  friend std::ostream& operator<<(ostream& os, Imag z) { os<<z.data[0]<<" + i"<<z.data[1]; return os; }
-  friend std::istream& operator>>(istream& is, Imag& z) { is>>z.data[0]>>z.data[1]; return is; }
+  friend std::ostream& operator<<(std::ostream& os, Imag z) { os<<z.data[0]<<" + i"<<z.data[1]; return os; }
+  friend std::istream& operator>>(std::istream& is, Imag& z) { is>>z.data[0]>>z.data[1]; return is; }
 
   /* WV added conversion operators to oldschool double[2] */
 #ifdef FFT3D
@@ -111,5 +114,7 @@ class Imag
 
 
 Imag expi(Real x);
+
+}
 
 #endif

--- a/LATfield2.hpp
+++ b/LATfield2.hpp
@@ -61,21 +61,22 @@
 
 #endif
 
-using namespace std;
 
-namespace LATfield2
-{
 #include "LATfield2_Lattice_decl.hpp"
-}
 
 #ifdef EXTERNAL_IO
 #include "LATfield2_IO_server.hpp"
-IOserver ioserver;
+namespace LATfield2
+{
+    IOserver ioserver;
+}
 #endif
 
 #include "LATfield2_parallel2d.hpp"
-Parallel2d parallel;
-
+namespace LATfield2
+{
+    Parallel2d parallel;
+}
 
 #include "LATfield2_SettingsFile.hpp"
 
@@ -91,27 +92,21 @@ Parallel2d parallel;
 #endif
 
 
-namespace LATfield2
-{
-        #include "int2string.hpp"
-        #include "Imag.hpp"
-        #include "LATfield2_Lattice.hpp"
-        #include "LATfield2_Site.hpp"
-        #include "LATfield2_Field.hpp"
-        #ifdef FFT3D
-            #include "LATfield2_PlanFFT.hpp"
-        #endif
-        #include "particles/LATfield2_Particles.hpp"
-        #ifdef CATALAT
-        #include "LATfield2_catalyst.hpp"
-        #endif
-
+#include "Imag.hpp"
+#include "int2string.hpp"
+#include "LATfield2_Lattice.hpp"
+#include "LATfield2_Site.hpp"
+#include "LATfield2_Field.hpp"
+#ifdef FFT3D
+    #include "LATfield2_PlanFFT.hpp"
+#endif
+#include "particles/LATfield2_Particles.hpp"
+#ifdef CATALAT
+    #include "LATfield2_catalyst.hpp"
+#endif
 
 //macros
-        #include  "looping_macro.hpp"
-
-
-}
+#include  "looping_macro.hpp"
 
 
 

--- a/LATfield2_Catalyst.hpp
+++ b/LATfield2_Catalyst.hpp
@@ -18,6 +18,10 @@
 #include <vtkPoints.h>
 #include <vtkPointData.h>
 
+namespace LATfield2
+{
+
+
 
 class CataLAT
 {
@@ -269,4 +273,6 @@ void CatalystCoProcess(int timeStep, double time, Field<double> * rho)
 
 
 */
+
+}
 #endif

--- a/LATfield2_Field.hpp
+++ b/LATfield2_Field.hpp
@@ -13,8 +13,10 @@
 
 //Matrix-style component symmetry
 
+namespace LATfield2
+{
 int symmetric = 1;
 int unsymmetric = 0;
-
+}
 
 #endif

--- a/LATfield2_Field_decl.hpp
+++ b/LATfield2_Field_decl.hpp
@@ -6,7 +6,12 @@
  \author David Daverio, Neil Bevis
  */
 
+#include <fstream>
 
+namespace LATfield2
+{
+
+    using std::fstream;
 //Matrix-style component symmetry
 
 inline int getCompSym(int i,int j)
@@ -1963,5 +1968,5 @@ void defaultFieldLoad(fstream& file, FieldType* siteData, int components)
 	for(int i=0; i<components; i++) { file>>siteData[i]; }
 }
 
-
+}
 #endif

--- a/LATfield2_IO_server.hpp
+++ b/LATfield2_IO_server.hpp
@@ -56,7 +56,8 @@
 
 #define MPI_BSEND_BUFFER_SIZE 40960
 
-
+namespace LATfield2
+{
 
 /*! \struct ioserver_file
     \brief Structure describing a output server file (used by compute processes)
@@ -2174,5 +2175,5 @@ void IOserver::write_files()
     
     //cout<<"write done"<<endl;
 }
-
+}
 #endif

--- a/LATfield2_Lattice.hpp
+++ b/LATfield2_Lattice.hpp
@@ -7,9 +7,12 @@
  \author David Daverio, Neil Bevis
  */ 
 
+#include <fstream>
 
+namespace LATfield2
+{
 
-
+    using std::fstream;
 
 
 //CONSTANTS=====================
@@ -431,5 +434,6 @@ long Lattice::siteLast() { return siteLast_; }
 int * Lattice::sizeLocalAllProcDim0(){ return sizeLocalAllProcDim0_; }
 int * Lattice::sizeLocalAllProcDim1(){ return sizeLocalAllProcDim1_; }
 
+}
 #endif
 

--- a/LATfield2_Lattice_decl.hpp
+++ b/LATfield2_Lattice_decl.hpp
@@ -10,6 +10,14 @@
  
  
  */
+
+#include <string>
+
+namespace LATfield2
+{
+ 
+ using std::string;
+ 
 class Lattice
 {
 public:
@@ -217,4 +225,5 @@ private:
     
 };
 
+}
 #endif

--- a/LATfield2_PlanFFT.hpp
+++ b/LATfield2_PlanFFT.hpp
@@ -9,7 +9,8 @@
 #include "LATfield2_PlanFFT_decl.hpp"
 
 
-
+namespace LATfield2
+{
 
 const int FFT_FORWARD = 1;
 const int FFT_BACKWARD = -1;
@@ -98,6 +99,6 @@ int temporaryMemFFT::setTemp(long size)
 temporaryMemFFT tempMemory;
 
 
-
+}
 
 #endif

--- a/LATfield2_PlanFFT_decl.hpp
+++ b/LATfield2_PlanFFT_decl.hpp
@@ -22,6 +22,9 @@
 /* these are not the actual compiler variables, these are
    only the declaration that they exist somewhere at all. */
 
+namespace LATfield2
+{
+
 extern  const int FFT_FORWARD;
 extern  const int FFT_BACKWARD;
 extern  const int FFT_IN_PLACE;
@@ -1561,5 +1564,5 @@ void PlanFFT<compType>::b_implement_0(fftw_complex * in, fftw_complex * out,int 
 
 #endif
 
-
+}
 #endif

--- a/LATfield2_SettingsFile.hpp
+++ b/LATfield2_SettingsFile.hpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <sstream>
 
+namespace LATfield2
+{
 //CLASS PROTOTYPE======================
 
 
@@ -451,5 +453,5 @@ bool SettingsFile::search(const std::string searchString)
     }
   return stream_.good();
 }
-
+}
 #endif

--- a/LATfield2_Site.hpp
+++ b/LATfield2_Site.hpp
@@ -8,6 +8,8 @@
 
 #include "LATfield2_Site_decl.hpp"
 
+namespace LATfield2
+{
 //CONSTRUCTORS===================
 
 Site::Site() {index_=0; lattice_ = NULL;}
@@ -196,7 +198,7 @@ bool Site::setCoordLocal(int *r)
 Lattice& Site::lattice() { return *lattice_ ; }
 
 
-ostream& operator<<(ostream& os,  Site& x)
+std::ostream& operator<<(std::ostream& os,  Site& x)
 {
     os << " (";
     int i=0;
@@ -418,5 +420,5 @@ bool rKSite::setCoord(int x, int y=0, int z=0)
 
 #endif
 
-
+}
 #endif

--- a/LATfield2_Site_decl.hpp
+++ b/LATfield2_Site_decl.hpp
@@ -2,7 +2,8 @@
 #define LATFIELD2_SITE_DECL_HPP
 
 
-
+namespace LATfield2
+{
 /*! \class Site
  \brief A class for referencing values of an instance of the field class at a given point on a lattice.
 
@@ -278,5 +279,5 @@ private:
 
 #endif
 
-
+}
 #endif

--- a/LATfield2_parallel2d.hpp
+++ b/LATfield2_parallel2d.hpp
@@ -3,6 +3,13 @@
 
 
 #include "LATfield2_parallel2d_decl.hpp"
+#include <iostream>
+
+namespace LATfield2
+{
+    using std::cerr;
+    using std::endl;
+    using std::cout;
 
 /////////// add verif for the 2*2 process and dim>2.
 
@@ -1694,5 +1701,7 @@ template<class Type> void Parallel2d::sendUpDown_dim1(Type& bufferSendUp,Type& b
             this->send_dim1( bufferSendDown, lenDown  , this->grid_size()[1]-1);
         }
     }
+}
+
 }
 #endif

--- a/LATfield2_parallel2d_decl.hpp
+++ b/LATfield2_parallel2d_decl.hpp
@@ -17,9 +17,11 @@
 //#if PARALLEL_MPI   //Define for MPI parallelism
 
 #include "mpi.h"
-#define COUT if(parallel.isRoot())cout
+#define COUT if(parallel.isRoot())std::cout
 
 
+namespace LATfield2
+{
 /*! \class Parallel2d
  \brief LATfield2d underliying class for paralleization
 
@@ -502,5 +504,5 @@ private:
 extern Parallel2d parallel;
 
 
-
+}
 #endif

--- a/LATfield2_save_hdf5.h
+++ b/LATfield2_save_hdf5.h
@@ -1,9 +1,8 @@
-
+#pragma once
 /*! \file LATfield2_save_hdf5.h
  \brief LATfield2_save_hdf5.h contains the definition of the function used for hdf5 i/o.
  \author David Daverio
  */
-extern "C"{
 
 #include <math.h>
 #include <hdf5.h>
@@ -11,6 +10,10 @@ extern "C"{
 #include <string.h>
 
 
+namespace LATfield2
+{
+
+extern "C"{
    int save_hdf5_externC(char *data,long file_offset[2],int *size,int * sizeLocal,int halo, int lat_dim,int comp,hid_t array_type,int array_size,string  filename_str, string dataset_name_str)
    {
 
@@ -369,4 +372,6 @@ template<class fieldType>
 int load_hdf5(fieldType *data,long file_offset[2],int *size,int * sizeLocal,int halo, int lat_dim,int comp,string  filename_str, string dataset_name_str)
 {
     return load_hdf5_externC( (char*) data, file_offset, size, sizeLocal, halo, lat_dim,  filename_str, dataset_name_str);
+}
+
 }

--- a/LATfield2_save_hdf5_pixie.h
+++ b/LATfield2_save_hdf5_pixie.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef BIG_ENDIAN_ORDER
 #define DATA_ORDER H5T_ORDER_BE
 #else
@@ -10,7 +12,6 @@
  */
 
 
-extern "C"{
 
 
 #include <math.h>
@@ -20,6 +21,10 @@ extern "C"{
 #include "int2string.hpp"
 #include <sys/stat.h>
 
+namespace LATfield2
+{
+
+extern "C"{
 inline bool file_exists(const std::string& name) {
   struct stat buffer;
   return (stat (name.c_str(), &buffer) == 0);
@@ -559,4 +564,6 @@ template<class fieldType>
 int load_hdf5(fieldType *data,long file_offset[2],int *size,int * sizeLocal,int halo, int lat_dim,int comp,string  filename_str, string dataset_name_str)
 {
     return load_hdf5_externC( (char*) data, file_offset, size, sizeLocal, comp, halo, lat_dim,  filename_str, dataset_name_str);
+}
+
 }

--- a/int2string.hpp
+++ b/int2string.hpp
@@ -8,6 +8,10 @@
  */
 
 #include <string>
+
+namespace LATfield2
+{
+
 using std::string;
 
 
@@ -44,4 +48,5 @@ string int2string(int number, int max = 999, bool zeropad = true)
   return output;
 }
 
+}
 #endif

--- a/particles/LATfield2_Particles.hpp
+++ b/particles/LATfield2_Particles.hpp
@@ -66,6 +66,14 @@
 #include "LATfield2_particlesIO.h"
 #endif
 
+#define GLOBAL_MASS     0
+#define INDIVIDUAL_MASS 1
+#define NO_MASS         2
+#include "projections.hpp"
+
+namespace LATfield2 
+{
+
 CREATE_MEMBER_DETECTOR(mass)
 CREATE_MEMBER_DETECTOR(ID)
 CREATE_MEMBER_DETECTOR(vel)
@@ -73,9 +81,6 @@ CREATE_MEMBER_DETECTOR(pos)
 CREATE_MEMBER_DETECTOR(type_name)
 CREATE_MEMBER_DETECTOR_MAXI(mass)
 
-#define GLOBAL_MASS     0
-#define INDIVIDUAL_MASS 1
-#define NO_MASS         2
 
 
 #define SUM             1
@@ -87,11 +92,9 @@ CREATE_MEMBER_DETECTOR_MAXI(mass)
 
 #define MAX_NUMBER 9223372036854775807
 
-using namespace LATfield2;
 
 template <typename part, typename part_info, typename part_dataType>
 class Particles;
-#include "projections.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 template <typename  part>
@@ -549,12 +552,12 @@ void Particles<part,part_info,part_dataType>::cout_particle_velocity_stats(const
   parallel.sum(mean,3);
   for(int i=0;i<3;i++)mean[i] /= count;
 
-  COUT<<"--- "<<text<<" velocity stats ---"<<setprecision(10)<<endl;
+  COUT<<"--- "<<text<<" velocity stats ---"<<std::setprecision(10)<<endl;
   for(int i=0;i<3;i++)
   {
     COUT<<"comp "<<i<< " : min "<<min[i]<< " ; max "<<max[i]<< " ; mean "<<mean[i]<<endl;
   }
-  COUT<<"----------------------"<<setprecision(6)<<endl;
+  COUT<<"----------------------"<<std::setprecision(6)<<endl;
 
 }
 
@@ -3055,6 +3058,6 @@ void Particles<part,part_info,part_dataType>::saveHDF5_server_write(string filen
 /**@}*/
 
 
-
+}
 
 #endif

--- a/particles/LATfield2_Particles.hpp
+++ b/particles/LATfield2_Particles.hpp
@@ -66,9 +66,9 @@
 #include "LATfield2_particlesIO.h"
 #endif
 
-#define GLOBAL_MASS     0
-#define INDIVIDUAL_MASS 1
-#define NO_MASS         2
+//#define GLOBAL_MASS     0
+//#define INDIVIDUAL_MASS 1
+//#define NO_MASS         2
 #include "projections.hpp"
 
 namespace LATfield2 
@@ -306,12 +306,12 @@ public:
      Method to get the mass type. The mass can be a global property (GLOBAL_MASS), a individual property (INDIVIDUAL_MASS) or can be not defined (NO_MASS).
      \return mass_type_
      */
-    int mass_type(){return mass_type_;};
+    // int mass_type(){return mass_type_;};
     /*!
      Method to get the offset of the mass property within its respective structure.
      \return mass_offset_
      */
-    size_t mass_offset(){return mass_offset_;};
+    // size_t mass_offset(){return mass_offset_;};
 
     long numParticles(){
       long temp = numParticles_;
@@ -332,8 +332,8 @@ protected:
 
   Field<partList<part>> field_part_;
 
-  int mass_type_;
-  size_t mass_offset_;
+  //int mass_type_;
+  //size_t mass_offset_;
 
   long numParticles_;
 
@@ -399,29 +399,31 @@ void Particles<part,part_info,part_dataType>::initialize(part_info part_global_i
 
   //does the mass is global or individual
 
-    has_maxi_mass<part> part_has_mass;
-    has_maxi_mass<part_info> info_has_mass;
+    // has_maxi_mass<part> part_has_mass;
+    // has_maxi_mass<part_info> info_has_mass;
 
 
 
-    if(part_has_mass.gos() != -1)
+    if( has_mass<part>::value )
     {
-        mass_offset_ = part_has_mass.gos();
+        //mass_offset_ = part_has_mass.gos();
         COUT<< "particles have individual mass" << endl;
-        mass_type_= INDIVIDUAL_MASS;
+        //mass_type_= INDIVIDUAL_MASS;
     }
-    else if(info_has_mass.gos() != -1)
+    else if( has_mass<part_info>::value )
     {
-        mass_offset_ = info_has_mass.gos();
-        COUT << "all particles have their mass set to: " << *(double*)((char*)&part_global_info_ + mass_offset_)<<endl;
-        mass_type_= GLOBAL_MASS;
+        // mass_offset_ = info_has_mass.gos();
+        COUT << "all particles have their mass set to: " << 
+        get_mass(part_global_info )
+        << std::endl;
+        // mass_type_= GLOBAL_MASS;
     }
     else
     {
         COUT<< "Particles have to have a mass!!! In part or in part_info."<<endl;
         COUT<< "no mass detected..."<<endl;
-        mass_type_= NO_MASS;
-        mass_offset_=-1;
+        //mass_type_= NO_MASS;
+        //mass_offset_=-1;
     }
 
 

--- a/particles/LATfield2_particle_description_template.hpp
+++ b/particles/LATfield2_particle_description_template.hpp
@@ -1,7 +1,8 @@
 #ifndef LATFIELD2_PARTICLE_DEF_HPP
 #define LATFIELD2_PARTICLE_DEF_HPP
 
-
+namespace LATfield2
+{
 /*! \file LATfield2_particle_description_template.hpp
  \brief Template to create a particle description
  
@@ -141,5 +142,5 @@ struct particles_name_dataType{
 
 /**@}*/
 
-
+}
 #endif

--- a/particles/LATfield2_particle_rk4.hpp
+++ b/particles/LATfield2_particle_rk4.hpp
@@ -1,6 +1,8 @@
 #ifndef LATFIELD2_PARTICLE_RK4_DEF_HPP
 #define LATFIELD2_PARTICLE_RK4_DEF_HPP
 
+namespace LATfield2
+{
 /*! \file LATfield2_particle_simple.hpp
  \brief Description of the particle type: "part_simple"
 
@@ -51,7 +53,7 @@ struct part_rk4{
  \brief overloading of the << operator for individual property strucutre.
  \return ostream containing the ID, position and velocity of the particle.
  */
-ostream& operator<<(ostream& os, const part_rk4& p)
+std::ostream& operator<<(std::ostream& os, const part_rk4& p)
 {
     os << "ID: "<<p.ID<<", mass: "<< p.mass<<" , Pos: ("<< p.pos[0]<<","<< p.pos[1]<<","<< p.pos[2]<<") , Vel: (" << p.vel[0]<<","<< p.vel[1]<<","<< p.vel[2]<<")";
     return os;
@@ -128,5 +130,5 @@ struct part_rk4_dataType{
 
 /**@}*/
 
-
+}
 #endif

--- a/particles/LATfield2_particle_simple.hpp
+++ b/particles/LATfield2_particle_simple.hpp
@@ -1,6 +1,9 @@
 #ifndef LATFIELD2_PARTICLE_DEF_HPP
 #define LATFIELD2_PARTICLE_DEF_HPP
 
+namespace LATfield2
+{
+
 /*! \file LATfield2_particle_simple.hpp
  \brief Description of the particle type: "part_simple"
 
@@ -47,7 +50,7 @@ struct part_simple{
  \brief overloading of the << operator for individual property strucutre.
  \return ostream containing the ID, position and velocity of the particle.
  */
-ostream& operator<<(ostream& os, const part_simple& p)
+std::ostream& operator<<(std::ostream& os, const part_simple& p)
 {
     os << "ID: "<<p.ID<<" , Pos: ("<< p.pos[0]<<","<< p.pos[1]<<","<< p.pos[2]<<") , Vel: (" << p.vel[0]<<","<< p.vel[1]<<","<< p.vel[2]<<")";
     return os;
@@ -131,5 +134,5 @@ struct part_simple_dataType{
 
 /**@}*/
 
-
+}
 #endif

--- a/particles/LATfield2_particlesIO.h
+++ b/particles/LATfield2_particlesIO.h
@@ -1,6 +1,11 @@
 #ifndef LATFIELD_PARTICLESIO_H
 #define LATFIELD_PARTICLESIO_H
 
+#include <string>
+
+namespace LATfield2
+{
+    using std::string;
 
 #ifndef RealC
 #ifdef SINGLE
@@ -625,5 +630,5 @@ int save_hdf5_particles(string filename,
     return 0;
 }
 
-
+}
 #endif

--- a/particles/move_function.hpp
+++ b/particles/move_function.hpp
@@ -9,8 +9,8 @@
  * @{
  */
 
-using namespace LATfield2;
-
+namespace LATfield2
+{
 
 void move_particles_simple(double dtau,
                                double lat_resolution,
@@ -30,7 +30,7 @@ void move_particles_simple(double dtau,
     for (int l=0;l<3;l++) (*part).pos[l] += dtau*(*part).vel[l];
    
 }
-
+}
 /**@}*/
 
 #endif

--- a/particles/particles_tools.hpp
+++ b/particles/particles_tools.hpp
@@ -1,6 +1,8 @@
 #ifndef PARTICLES_TOOLS_HPP
 #define PARTICLES_TOOLS_HPP
 
+namespace LATfield2
+{
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 LATfield2::Real get_lattice_resolution(int npts[3],LATfield2::Real boxSize[3])
@@ -41,5 +43,7 @@ LATfield2::Real get_lattice_resolution(int npts[3],LATfield2::Real boxSize[3])
 };
 
 #endif
+
+}
 
 #endif

--- a/particles/particles_tools.hpp
+++ b/particles/particles_tools.hpp
@@ -1,6 +1,14 @@
 #ifndef PARTICLES_TOOLS_HPP
 #define PARTICLES_TOOLS_HPP
 
+#include <type_traits>
+#if __cplusplus < 201700L
+namespace std
+{
+    template<typename ...> using void_t = void;
+};
+#endif
+
 namespace LATfield2
 {
 
@@ -20,16 +28,24 @@ LATfield2::Real get_lattice_resolution(int npts[3],LATfield2::Real boxSize[3])
   }
 }
 
+#define CREATE_MEMBER_DETECTOR(X)                \
+template<typename T, typename = std::void_t<> >  \
+struct has_##X : std::false_type                 \
+{};                                              \
+template<typename T>                             \
+struct has_##X<T, std::void_t<decltype(T::X)> >  \
+    : std::true_type                             \
+{};
 
-#define CREATE_MEMBER_DETECTOR(X)            \
-  template<typename T> struct has_##X {      \
-    struct Fallback {int X; };               \
-    struct Derived : T, Fallback { };        \
-    template<typename C, C> struct ChT;      \
-    template<typename C> static char (&f(ChT<int Fallback::*, &C::X>*))[1]; \
-    template<typename C> static char (&f(...))[2]; \
-    static bool const value = sizeof(f<Derived>(0)) == 2; \
-  };
+//#define CREATE_MEMBER_DETECTOR(X)            \
+//  template<typename T> struct has_##X {      \
+//    struct Fallback {int X; };               \
+//    struct Derived : T, Fallback { };        \
+//    template<typename C, C> struct ChT;      \
+//    template<typename C> static char (&f(ChT<int Fallback::*, &C::X>*))[1]; \
+//    template<typename C> static char (&f(...))[2]; \
+//    static bool const value = sizeof(f<Derived>(0)) == 2; \
+//  };
 
 
 #define CREATE_MEMBER_DETECTOR_MAXI(X)          \

--- a/particles/particles_tools.hpp
+++ b/particles/particles_tools.hpp
@@ -35,7 +35,41 @@ struct has_##X : std::false_type                 \
 template<typename T>                             \
 struct has_##X<T, std::void_t<decltype(T::X)> >  \
     : std::true_type                             \
-{};
+{};                                              \
+
+#define CREATE_MEMBER_DETECTOR_MAXI(X)           \
+template<class P, class I>                       \
+typename std::enable_if< has_##X<P>::value       \
+    , double>::type                              \
+get_##X( const P& p,const I&)                    \
+{ return p.X; }                                  \
+template<class P, class I>                       \
+typename std::enable_if<                         \
+    has_##X<P>::value==false                     \
+    and has_##X<I>::value ,double>::type         \
+get_##X(const P&,const I& i)                     \
+{  return i.X; }                                 \
+template<class P, class I>                       \
+typename std::enable_if< has_##X<P>::value       \
+    ,double&>::type                              \
+get_##X(P& p,const I&)                           \
+{ return p.X;}                                   \
+template<class P, class I>                       \
+typename std::enable_if<                         \
+    has_##X<P>::value==false                     \
+    and has_##X<I>::value ,double&>::type        \
+get_##X(const P&,I& i)                           \
+{ return i.X; }                                  \
+template<class I>                                \
+typename std::enable_if<                         \
+    has_##X<I>::value==true ,double>::type       \
+get_##X(const I& i)                              \
+{  return i.X; }                                 \
+template<class I>                                \
+typename std::enable_if<                         \
+    has_##X<I>::value==false ,double>::type      \
+get_##X(const I& i)                              \
+{  return -1.0; }                                \
 
 //#define CREATE_MEMBER_DETECTOR(X)            \
 //  template<typename T> struct has_##X {      \
@@ -48,15 +82,15 @@ struct has_##X<T, std::void_t<decltype(T::X)> >  \
 //  };
 
 
-#define CREATE_MEMBER_DETECTOR_MAXI(X)          \
-    template<typename T> struct has_maxi_##X {      \
-    struct Fallback {int X; };               \
-    struct Derived : T, Fallback { };        \
-    template<typename C, C> struct ChT;      \
-    template<typename C,typename CC> int (f(ChT<int Fallback::*, &C::X>*)){return -1;}; \
-    template<typename C,typename CC> int (f(...)){return offsetof(T,X);}; \
-    int gos(){return f<Derived,T>(0);} \
-};
+// #define CREATE_MEMBER_DETECTOR_MAXI(X)          \
+//     template<typename T> struct has_maxi_##X {      \
+//     struct Fallback {int X; };               \
+//     struct Derived : T, Fallback { };        \
+//     template<typename C, C> struct ChT;      \
+//     template<typename C,typename CC> int (f(ChT<int Fallback::*, &C::X>*)){return -1;}; \
+//     template<typename C,typename CC> int (f(...)){return offsetof(T,X);}; \
+//     int gos(){return f<Derived,T>(0);} \
+// };
 
 #endif
 

--- a/particles/projections.hpp
+++ b/particles/projections.hpp
@@ -1,7 +1,11 @@
 #ifndef LATFIELD2_PROJECTIONS_HPP
 #define LATFIELD2_PROJECTIONS_HPP
 
+namespace LATfield2
+{
 
+template <typename part, typename part_info, typename part_dataType>
+class Particles;
 
 /*! \file projections.hpp
  \brief projection function for scalar, vector and tensor particle properties.
@@ -1814,6 +1818,6 @@ void VecVecProjectionCIC_comm(Field<Real> * Tij)
 }
 
 #endif
-
+}
 /**@}*/
 #endif

--- a/particles/projections.hpp
+++ b/particles/projections.hpp
@@ -39,8 +39,8 @@ void projection_init(Field<Real> * f)
 
 
 
-static int const FROM_PART = INDIVIDUAL_MASS;
-static int const FROM_INFO = GLOBAL_MASS;
+//static int const FROM_PART = INDIVIDUAL_MASS;
+//static int const FROM_INFO = GLOBAL_MASS;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -77,7 +77,7 @@ int CIC_mapv2[2][2][2][2] =   { { {{24,28},{25,29}},{{26,30},{27,31}} } , { {{28
  \sa projection_init(Field<Real> * f)
  */
 template<typename part, typename part_info, typename part_dataType>
-void scalarProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * rho, size_t * oset = NULL,int flag_where = FROM_INFO)
+void scalarProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * rho)
 {
 
     if(rho->lattice().halo() == 0)
@@ -100,34 +100,34 @@ void scalarProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
     double rescalPosDown[3];
     double latresolution = parts->res();
 
-    double mass;
+    // double mass;
     double cicVol;
     cicVol= latresolution*latresolution*latresolution;
     cicVol *= cicVol;
 
     Real localCube[8]; // XYZ = 000 | 001 | 010 | 011 | 100 | 101 | 110 | 111
 
-    int sfrom;
+    //int sfrom;
 
-    size_t offset;
+    //size_t offset;
 
-    if(oset == NULL)
-    {
-        sfrom = parts->mass_type();
-        offset = parts->mass_offset();
-    }
-    else
-    {
-        sfrom =  flag_where;
-        offset = *oset;
-    }
+    //if(oset == NULL)
+    //{
+    //    sfrom = parts->mass_type();
+    //    offset = parts->mass_offset();
+    //}
+    //else
+    //{
+    //    sfrom =  flag_where;
+    //    offset = *oset;
+    //}
 
-    if(sfrom == FROM_INFO)
-    {
-        mass = *(double*)((char*)parts->parts_info() + offset);
-        mass /= cicVol;
-        //cout << mass<<endl;
-    }
+    //if(sfrom == FROM_INFO)
+    //{
+    //    mass = *(double*)((char*)parts->parts_info() + offset);
+    //    mass /= cicVol;
+    //    //cout << mass<<endl;
+    //}
 
 
 
@@ -148,12 +148,15 @@ void scalarProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
                     rescalPos[i]=(*it).pos[i]-referPos[i];
                     rescalPosDown[i]=latresolution -rescalPos[i];
                 }
-
-                if(sfrom==FROM_PART)
-                {
-                    mass = *(double*)((char*)&(*it)+offset);
+                
+                
+                //if(sfrom==FROM_PART)
+                //{
+                //    mass = *(double*)((char*)&(*it)+offset);
+                //    mass /=cicVol;
+                //}
+                double mass = get_mass(*it,*parts->parts_info());
                     mass /=cicVol;
-                }
 
                 //000
                 localCube[0] += rescalPosDown[0]*rescalPosDown[1]*rescalPosDown[2] * mass;
@@ -423,7 +426,7 @@ void vertexProjectionCIC_comm(Field<Real> * vel)
  \sa projection_init(Field<Real> * f)
  */
 template<typename part, typename part_info, typename part_dataType>
-void vectorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * vel, size_t * oset = NULL,int flag_where = FROM_INFO)
+void vectorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * vel, size_t * oset = NULL)
 {
     Site xPart(parts->lattice());
     Site xVel(vel->lattice());
@@ -432,7 +435,7 @@ void vectorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * pa
 
     double vi[36];//3 * 4 v0:0..3 v1:4..7 v2:8..11
 
-    double mass;
+    //double mass;
     double latresolution = parts->res();
 
     double cicVol = latresolution * latresolution * latresolution;
@@ -443,32 +446,32 @@ void vectorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * pa
     double referPos[3];
 
 
-    int sfrom;
+    //int sfrom;
 
-    size_t offset_mass;
+    //size_t offset_mass;
     size_t offset_vel;
 
 
 
     if(oset == NULL)
     {
-        sfrom = parts->mass_type();
-        offset_mass = parts->mass_offset();
+        //sfrom = parts->mass_type();
+        //offset_mass = parts->mass_offset();
         offset_vel = offsetof(part,vel);
     }
     else
     {
-        sfrom =  flag_where;
-        offset_mass = oset[0];
+        //sfrom =  flag_where;
+        //offset_mass = oset[0];
         offset_vel = oset[1];
     }
 
-    if(sfrom == FROM_INFO)
-    {
-        mass = *(double*)((char*)parts->parts_info() + offset_mass);
-        mass /= cicVol;
-        //cout << mass<<endl;
-    }
+    //if(sfrom == FROM_INFO)
+    //{
+    //    mass = *(double*)((char*)parts->parts_info() + offset_mass);
+    //    mass /= cicVol;
+    //    //cout << mass<<endl;
+    //}
 
 
 
@@ -494,11 +497,13 @@ void vectorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * pa
                 double massVel;
                 Real * v;
 
-                if(sfrom==FROM_PART)
-                {
-                    mass = *(double*)((char*)&(*it)+offset_mass);
-                    mass /= cicVol;
-                }
+                //if(sfrom==FROM_PART)
+                //{
+                //    mass = *(double*)((char*)&(*it)+offset_mass);
+                //    mass /= cicVol;
+                //}
+                double mass = get_mass(*it,*parts->parts_info());
+                mass /= cicVol;
                 v = (Real*)((char*)&(*it)+offset_vel);
                 //cout<< v[0]<<" , "<<v[1]<<" , "<<v[2]<<endl;
 
@@ -710,7 +715,7 @@ void vectorProjectionCICNGP_comm(Field<Real> * vel)
  \sa projection_init(Field<Real> * f)
  */
 template<typename part, typename part_info, typename part_dataType>
-void symtensorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * Tij, size_t * oset = NULL,int flag_where = FROM_INFO)
+void symtensorProjectionCICNGP_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * Tij, size_t * oset = NULL)
 {
 
     Site xPart(parts->lattice() );
@@ -718,7 +723,7 @@ void symtensorProjectionCICNGP_project(Particles<part,part_info,part_dataType> *
 
     typename std::list<part>::iterator it;
 
-    double mass;
+    //double mass;
     double latresolution = parts->res();
     double cicVol = latresolution * latresolution * latresolution;
 
@@ -731,32 +736,32 @@ void symtensorProjectionCICNGP_project(Particles<part,part_info,part_dataType> *
     double referPos[3];
 
 
-    int sfrom;
+    //int sfrom;
 
-    size_t offset_mass;
+    //size_t offset_mass;
     size_t offset_vel;
 
 
 
     if(oset == NULL)
     {
-        sfrom = parts->mass_type();
-        offset_mass = parts->mass_offset();
+        //sfrom = parts->mass_type();
+        //offset_mass = parts->mass_offset();
         offset_vel = offsetof(part,vel);
     }
     else
     {
-        sfrom =  flag_where;
-        offset_mass = oset[0];
+        //sfrom =  flag_where;
+        //offset_mass = oset[0];
         offset_vel = oset[1];
     }
 
-    if(sfrom == FROM_INFO)
-    {
-        mass = *(double*)((char*)parts->parts_info() + offset_mass);
-        mass /= cicVol;
-        //cout << mass<<endl;
-    }
+    //if(sfrom == FROM_INFO)
+    //{
+    //    mass = *(double*)((char*)parts->parts_info() + offset_mass);
+    //    mass /= cicVol;
+    //    //cout << mass<<endl;
+    //}
 
 
 
@@ -779,11 +784,13 @@ void symtensorProjectionCICNGP_project(Particles<part,part_info,part_dataType> *
                 }
 
                 Real * vel;
-                if(sfrom==FROM_PART)
-                {
-                    mass = *(double*)((char*)&(*it)+offset_mass);
-                    mass /= cicVol;
-                }
+                //if(sfrom==FROM_PART)
+                //{
+                //    mass = *(double*)((char*)&(*it)+offset_mass);
+                //    mass /= cicVol;
+                //}
+                double mass = get_mass(*it,*parts->parts_info());
+                    mass /=cicVol;
                 vel = (Real*)((char*)&(*it)+offset_vel);
 
 
@@ -981,7 +988,7 @@ void symtensorProjectionCICNGP_comm(Field<Real> * Tij)
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<typename part, typename part_info, typename part_dataType>
-void vectorProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * vel, size_t * oset = NULL,int flag_where = FROM_INFO)
+void vectorProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * vel, size_t * oset = NULL)
 {
 
     Site xPart(parts->lattice());
@@ -989,7 +996,7 @@ void vectorProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
 
     typename std::list<part>::iterator it;
 
-    double mass;
+    //double mass;
     double latresolution = parts->res();
     double cicVol = latresolution * latresolution * latresolution;
 
@@ -1009,32 +1016,32 @@ void vectorProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
 
 
 
-    int sfrom;
+    //int sfrom;
 
-    size_t offset_mass;
+    //size_t offset_mass;
     size_t offset_vel;
 
 
 
     if(oset == NULL)
     {
-        sfrom = parts->mass_type();
-        offset_mass = parts->mass_offset();
+        //sfrom = parts->mass_type();
+        //offset_mass = parts->mass_offset();
         offset_vel = offsetof(part,vel);
     }
     else
     {
-        sfrom =  flag_where;
-        offset_mass = oset[0];
+        //sfrom =  flag_where;
+        //offset_mass = oset[0];
         offset_vel = oset[1];
     }
 
-    if(sfrom == FROM_INFO)
-    {
-        mass = *(double*)((char*)parts->parts_info() + offset_mass);
-        mass /= cicVol;
-        //cout << mass<<endl;
-    }
+    //if(sfrom == FROM_INFO)
+    //{
+    //    mass = *(double*)((char*)parts->parts_info() + offset_mass);
+    //    mass /= cicVol;
+    //    //cout << mass<<endl;
+    //}
 
 
     for(xPart.first(),xVel.first();xPart.test();xPart.next(),xVel.next())
@@ -1076,13 +1083,15 @@ void vectorProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
 
                 Real * v;
                 double massVel;
+                double mass = get_mass(*it,*parts->parts_info());
+                    mass /=cicVol;
 
 
-                if(sfrom==FROM_PART)
-                {
-                    mass = *(double*)((char*)&(*it)+offset_mass);
-                    mass /= cicVol;
-                }
+                //if(sfrom==FROM_PART)
+                //{
+                //    mass = *(double*)((char*)&(*it)+offset_mass);
+                //    mass /= cicVol;
+                //}
 
                 v = (Real*)((char*)&(*it)+offset_vel);
 
@@ -1357,14 +1366,14 @@ void vectorProjectionCIC_comm(Field<Real> * vel)
 
 
 template<typename part, typename part_info, typename part_dataType>
-void VecVecProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * Tij, size_t * oset = NULL,int flag_where = FROM_INFO)
+void VecVecProjectionCIC_project(Particles<part,part_info,part_dataType> * parts,Field<Real> * Tij, size_t * oset = NULL)
 {
     Site xPart(parts->lattice());
     Site xTij(Tij->lattice());
     typename std::list<part>::iterator it;
 
 
-    double mass;
+    //double mass;
     double latresolution = parts->res();
     double cicVol = latresolution * latresolution * latresolution;
 
@@ -1384,32 +1393,32 @@ void VecVecProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
     double referPos[3];
     double referPosShift[3];
 
-    int sfrom;
+    //int sfrom;
 
-    size_t offset_mass;
+    //size_t offset_mass;
     size_t offset_vel;
 
 
 
     if(oset == NULL)
     {
-        sfrom = parts->mass_type();
-        offset_mass = parts->mass_offset();
+        //sfrom = parts->mass_type();
+        //offset_mass = parts->mass_offset();
         offset_vel = offsetof(part,vel);
     }
     else
     {
-        sfrom =  flag_where;
-        offset_mass = oset[0];
+        //sfrom =  flag_where;
+        //offset_mass = oset[0];
         offset_vel = oset[1];
     }
 
-    if(sfrom == FROM_INFO)
-    {
-        mass = *(double*)((char*)parts->parts_info() + offset_mass);
-        mass /= cicVol;
-        //cout << mass<<endl;
-    }
+    //if(sfrom == FROM_INFO)
+    //{
+    //    mass = *(double*)((char*)parts->parts_info() + offset_mass);
+    //    mass /= cicVol;
+    //    //cout << mass<<endl;
+    //}
 
 
 
@@ -1449,11 +1458,13 @@ void VecVecProjectionCIC_project(Particles<part,part_info,part_dataType> * parts
 
                 }
                 Real * vel;
-                if(sfrom==FROM_PART)
-                {
-                    mass = *(double*)((char*)&(*it)+offset_mass);
-                    mass /= cicVol;
-                }
+                //if(sfrom==FROM_PART)
+                //{
+                //    mass = *(double*)((char*)&(*it)+offset_mass);
+                //    mass /= cicVol;
+                //}
+                double mass = get_mass(*it,*parts->parts_info());
+                    mass /=cicVol;
                 vel = (Real*)((char*)&(*it)+offset_vel);
 
 

--- a/particles/updateVel_function.hpp
+++ b/particles/updateVel_function.hpp
@@ -3,7 +3,8 @@
 
 
 
-using namespace LATfield2;
+namespace LATfield2
+{
 
 /**
  * \addtogroup prartClass
@@ -38,5 +39,5 @@ Real updateVel_simple(double dtau,
 }
 
 /**@}*/
-
+}
 #endif

--- a/timer.hpp
+++ b/timer.hpp
@@ -1,6 +1,8 @@
 #ifndef TIMER_HPP
 #define TIMER_HPP
 
+namespace LATfield2
+{
 
 string second2time(double in)
 {
@@ -175,5 +177,5 @@ double MPI_timer::getTime(int i)
     return -1;
   }
 }
-
+}
 #endif


### PR DESCRIPTION
This branch implements the SFINAE handling of particle masses without the need of data member pointers. (see issue #16). After these changes `gevolution` will compile by changing three lines of code in `gevolution.hpp`:
```
$ git diff
diff --git a/gevolution.hpp b/gevolution.hpp
index e737997..b9ea4c4 100644
--- a/gevolution.hpp
+++ b/gevolution.hpp
@@ -911,7 +911,7 @@ void projection_T00_project(Particles<part, part_info, part_dataType> * pcls, Fi
        Real dx = pcls->res();
        
        double mass = coeff / (dx*dx*dx);
-       mass *= *(double*)((char*)pcls->parts_info() + pcls->mass_offset());
+       mass *= pcls->parts_info() -> mass;
        mass /= a;
        
        Real e = a, f = 0.;
@@ -1030,7 +1030,7 @@ void projection_T0i_project(Particles<part,part_info,part_dataType> * pcls, Fiel
        Real dx = pcls->res();
        
        double mass = coeff / (dx*dx*dx);
-       mass *= *(double*)((char*)pcls->parts_info() + pcls->mass_offset());
+       mass *= pcls->parts_info()->mass;
     
     Real w;
        Real * q;
@@ -1157,7 +1157,7 @@ void projection_Tij_project(Particles<part, part_info, part_dataType> * pcls, Fi
        Real dx = pcls->res();
        
        double mass = coeff / (dx*dx*dx);
-       mass *= *(double*)((char*)pcls->parts_info() + pcls->mass_offset());
+       mass *= pcls->parts_info() -> mass;
        mass /= a;
        
        Real e, f, w;

```

whenever 
```
 mass *= *(double*)((char*)pcls->parts_info() + pcls->mass_offset());
```
must be replaced with
```
 mass *= pcls->parts_info() -> mass;
```