### PR TITLE
Fix stack smashing bug at two places in LATfield2_save_hdf.h

### DIFF
--- a/LATfield2_save_hdf5.h
+++ b/LATfield2_save_hdf5.h
@@ -23,7 +23,7 @@ extern "C"{
      filename[filename_str.size()] = '\0';
 
 	   char  dataset_name[128];
-	   for(int i = 0;i<filename_str.size();i++)dataset_name[i]=dataset_name_str[i];
+	   for(int i = 0;i<dataset_name_str.size();i++)dataset_name[i]=dataset_name_str[i];
 	   dataset_name[dataset_name_str.size()] = '\0';
 
 	   herr_t status;
@@ -234,7 +234,7 @@ extern "C"{
 		filename[filename_str.size()] = '\0';
 
 		char  dataset_name[128];
-		for(int i = 0;i<filename_str.size();i++)dataset_name[i]=dataset_name_str[i];
+		for(int i = 0;i<dataset_name_str.size();i++)dataset_name[i]=dataset_name_str[i];
 		dataset_name[dataset_name_str.size()] = '\0';
 
 		herr_t status;


### PR DESCRIPTION
The file 'LATfield2_save_hdf.h' has a routine
'save_hdf5_externC(...)'  in which it copies each character of a
filename stored as a string into another sequence of bytes in
memory where a string is to be stored ('filename_str'). It also
does the same thing for a string parameter that by default has the
literal string "data" as its value, and is to be stored in
'dataset_name_str'.

However, the number of characters copied for the second string
was accidentally done using the size of the first string.  Since
a filename (the first string) will in practice usually be a lot
longer than four characters, this will in general try to copy
bytes between two unallocated areas of memory. This is a coding
error that has been detected in real-world calculations as stack
smashing [1].

This commit f27070f  corrects this error in 'save_hdf5_externC(...)' and
in 'load_hdf5_externC(...)' in the same file,
'LATfield2_save_hdf5.h'. This solves bug  #18 for me.

[1] https://en.wikipedia.org/wiki/Stack_buffer_overflow